### PR TITLE
無名関数を使ったFile.Closeのサンプルコードを修正

### DIFF
--- a/books/golang-io-package/file.md
+++ b/books/golang-io-package/file.md
@@ -197,7 +197,7 @@ if err != nil {
 +	if err != nil {
 +		fmt.Println(err)
 +	}
-+ }
++ }()
 
 // 以下write処理等を書く
 ```


### PR DESCRIPTION
[Goから学ぶI/O](https://zenn.dev/hsaki/books/golang-io-package) 読ませていただきました。
とてもわかりやすく勉強になりました、ありがとうございます。

細かい指摘ですみませんが、Chapter 02の [無名関数を使って Close を処理するサンプルコード](https://zenn.dev/hsaki/books/golang-io-package/viewer/file#%E5%BF%9C%E7%94%A8) で `()` が抜けているのではないかと思いました。
ご確認いただけると助かります。