### PR TITLE
hello.protoファイルの修正

### DIFF
--- a/books/golang-grpc-starting/proto.md
+++ b/books/golang-grpc-starting/proto.md
@@ -16,6 +16,9 @@ syntax = "proto3";
 // packageの宣言
 package myapp;
 
+// go_packageのPATH
+option go_package = "../";
+
 // サービスの定義
 service GreetingService {
 	// サービスが持つメソッドの定義


### PR DESCRIPTION
[作ってわかる！ はじめてのgRPC](https://zenn.dev/hsaki/books/golang-grpc-starting)読ませていただいております。
勉強させていただきます。

[Chapter04のコードの生成](https://zenn.dev/hsaki/books/golang-grpc-starting/viewer/codegenerate#%E3%82%B3%E3%83%BC%E3%83%89%E3%81%AE%E7%94%9F%E6%88%90)にて下記エラーが発生しましたので、`hello.proto`に`option go_package`を追記しました。
（Chapter04に合わせましたので、不自然な形ですが・・・）

ご確認いただけますと幸いです。

```
protoc-gen-go: unable to determine Go import path for "hello.proto"

Please specify either:
        • a "go_package" option in the .proto source file, or
        • a "M" argument on the command line.
```

